### PR TITLE
Fix a few grammatical and spelling mistakes

### DIFF
--- a/report/architecture.tex
+++ b/report/architecture.tex
@@ -1,37 +1,37 @@
 \section{Project Architecture}
 
-The project is composed by the following entities:
+The project is composed of the following entities:
 
 \begin{description}
-  \item[FaceDetector:] an utility class that extracts faces from images.
-  \item[GaborBank:] generator of features using gabor filters.
-  \item[Classifier:] generic 2-class classificator, which can be
+  \item[FaceDetector:] a utility class that extracts faces from images.
+  \item[GaborBank:] generator of features using Gabor filters.
+  \item[Classifier:] generic 2-class classifier, which can be
     trained to predict a feature matrix.
-  \item[EmoDetector:] using a set of classifiers, it realizes a multi-class
+  \item[EmoDetector:] using a set of classifiers, it realizes multi-class
     detection for emotions.
   \item[GUI:] generic GUI that uses an EmoDetector to predict the emotion.
 \end{description}
 
-Instead of creating a single executable that does everything, we choose a
+Instead of creating a single executable that does everything, we chose a
 \emph{linux-like} approach of having a set of tools, where each of them
 performs a single task.
 
-Thus, we created a set of efficient tools, written in \code{C++}, which perform
+Thus, we created a set of efficient tools, written in \code{C++}, which performs
 training and detection, while high-level tasks such as data and training
 organization are done by \code{Python} scripts.
 
 \subsection{Face detection}
 
 The face detection task is realized by the class \code{FaceDetector}. It uses
-trained \emph{Haar Cascadesthe} classifiers to detect and crop the first face
+trained \emph{Haar Cascades} classifiers to detect and crop the first face
 from an image.
 
-Since the face can be partially occulted or rotated around the principal axis,
+Since the face can be partially occluded or rotated around the principal axis,
 mere detection is not enough. We implemented only the roll correction, by using
-another \emph{Haar Cascadesthe} classifier to detect the eyes coordinates. If
-the eye are not on the same axis, the image is rotated.
+another \emph{Haar Cascades} classifier to detect the eyes coordinates. If
+the eyes are not on the same axis, the image is rotated.
 
-The face detection receives as input an image and outputs a matrix containing
+The face detection receives an image as an input and outputs a matrix containing
 the cropped and adjusted face.
 
 \subsection{Gabor bank}
@@ -45,20 +45,20 @@ contains a stack of images, one for each filter present in the bank.
 
 \subsection{Classifier}
 
-\code{Classifier} is a generic 2-class classificator, which can be trained to
-predict a feature matrix. The specializations classes we implemented are
+\code{Classifier} is a generic 2-class classifier, which can be trained to
+predict the label of a feature matrix. The specializations classes we implemented are
 \code{SVMClassifier} and \code{AdaBoostClassifier}.
 
-The training set is composed by \emph{negative} (class 0) and \emph{positive}
+The training set is composed of \emph{negative} (class 0) and \emph{positive}
 (class 1) samples. The output is a trained classifier. We used the
-\emph{OpenCV} \code{CvSVM} and \code{CvBoost}, which permit to save and load
+\emph{OpenCV}, \code{CvSVM} and \code{CvBoost}, which permit to save and load
 their internal state.
 
 \subsection{Emotion detector}
 
 Once the 2-class classifiers are trained, they can be used together to realize
 a multi-class classifiers. This goal is achieved by \code{EmoDetector}. It is
-composed by multiple \code{Classifier} and combines their prediction in various
+composed of multiple \code{Classifier} and combines their prediction in various
 ways to detect the emotion.
 
 The input is an image, which is preprocessed: the face is extracted and then
@@ -68,7 +68,7 @@ score.
 \subsection{GUI}
 
 The GUI is realized using the \emph{OpenCV} API. A generic GUI (\code{AGui}) is
-composed by a \code{FacePreProcessor}, which extracts features from images, an
+composed of a \code{FacePreProcessor}, which extracts features from images, an
 \code{EmoDetector} and a \code{ACapture}.
 
 An \code{ACapture} is a generic frame capture. The specializations we
@@ -80,15 +80,15 @@ Tools are \code{C++} programs performing high-performance tasks. In order
 to be generic, they require every algorithm parameter as input argument.
 
 \begin{description}
-  \item[facecrop\_cli] reads an image and output a new image with the cropped
-    face. It performs also eye-adjusting.
-  \item[gaborbank\_cli] reads an image and output a file containing the
+  \item[facecrop\_cli] reads an image and outputs a new image with the cropped
+    face. It also performs eye-adjusting.
+  \item[gaborbank\_cli] reads an image and outputs a file containing the
     extracted features.
   \item[train\_cli] reads a training file, trains a classifier and writes the
     trained state in an output file in \emph{xml} format.
-  \item[emo\_detector\_cli] reads images and detect emotions using trained
+  \item[emo\_detector\_cli] reads images and detects emotions using trained
     classifiers.
-  \item[emotimegui\_cli] capture the webcam and performs real-time emotion
+  \item[emotimegui\_cli] captures the webcam and performs real-time emotion
     detection.
 \end{description}
 
@@ -105,10 +105,10 @@ parameters, are read from a configuration file.
   \item[datasetFeatures.py] uses the gaborbank tool to extract features from
     the faces. The features are saved as \emph{yml} files.
   \item[datasetPrepTrain.py] prepares the training files by combining the
-    features files using various strategies. The output are \emph{csv} files
+    features files using various strategies. The outputs are \emph{csv} files
     containing the positive and negative samples.
-  \item[datasetTrain.py] iterates the \emph{csv} training files and launch a
-    multi-threading training using the train tool. Their output is trained
+  \item[datasetTrain.py] iterates the \emph{csv} training files and launches a
+    multi-threading training using the train tool. Its outputs are trained
     classifiers, which are saved in the \code{dataset} as \code{xml} files.
   \item[datasetVerifyPrediction.py] uses the emo\_detector tool to verify the
     prediction of the trained classifiers. We don't have a \emph{validation

--- a/report/organization.tex
+++ b/report/organization.tex
@@ -1,20 +1,20 @@
 \section{Project organization and usage}
 
-The project is managed by \emph{CMake} and its organized as following:
+The project is managed by \emph{CMake} and it's organized as follows:
 
 \begin{verbatim}
 
 src
   \-->dataset      Scripts for dataset management
-  \-->detector     Multiclass detector and preprocessor
+  \-->detector     Multi-class detector and preprocessor
   \-->facedetector Face cropping, adjusting and registration
-  \-->gaborbank    Generation of gabor filters and image filtering
+  \-->gaborbank    Generation of Gabor filters and image filtering
   \-->gui          Graphical interfaces and interaction with videos and webcam
   \-->training     2-class training and prediction
   \-->utils        String and IO utilities, CSV supports, and so on..
 doc                Documentation (doxigen)
 report             Report sources
-resources          Containing third party resources (eg. OpenCV haar classifiers)
+resources          Containing third party resources (e.g. OpenCV haar classifiers)
 assets             Binary folder
 
 \end{verbatim}
@@ -32,7 +32,7 @@ without python is not recommended.
 
 \subsection{Compilation on Linux}
 
-Just like any other \emph{CMake} projects, the first step is to initialize the
+Just like any other \emph{CMake} project, the first step is to initialize the
 compilation by doing:
 
 \begin{verbatim}
@@ -46,21 +46,21 @@ scripts in the \code{assets} directory.
 
 \subsection{Compilation on Windows}
 
-We have tested the compilation and usage on windows 8.1 using Visual Studio 12
-64bit. However it should work with any version:
+We have tested the compilation and usage on Windows 8.1 using Visual Studio 12
+(64-bit). However, it should work with any version:
 
 \begin{enumerate}
   \item Using CMake or CMakeGUI, select emotime as source folder and configure.
-  \item If it complains about setting the variable \code{OpenCV\_DIR} set it to the appropriate path so that:
+  \item If it complains about setting the variable \code{OpenCV\_DIR}, set it to the appropriate path, so that:
     \begin{enumerate}
       \item \code{C:/path/to/opencv/dir/} contains the libraries (\code{*.lib})
       \item \code{C:/path/to/opencv/dir/include} contains the include
         directories (opencv and opencv2). \textbf{IF the include directory is
-        not in the right position} the project will likely not be able to
+        not in the right position}, the project will likely not be able to
         compile due to missing reference to \code{opencv2/opencv} or similar.
     \end{enumerate}
   \item Then generate the project and compile the project \code{ALL\_BUILD}
-  \item If the compilation succeeded, compile the project \code{INSTALL}
+  \item If the compilation succeeds, compile the project \code{INSTALL}
   \item Now all scripts, configuration and tools should be in the directory
     \code{assets} in the project source directory.
 \end{enumerate}
@@ -92,11 +92,11 @@ python2 datasetFillCK.py /path/to/dataset \
 
 \subsubsection*{Classifier training}
 
-Your console console working directory must be the \code{assest} directory,
+Your console's working directory must be the \code{assets} directory,
 with all the scripts and clis present. Assuming your configuration is in the
-assest directory, named \code{dataset.cfg}, the script \code{train\_models.py}
+assets directory, named \code{dataset.cfg}, the script \code{train\_models.py}
 automatize the training procedure. \textbf{Remember} this script must be called
-inside the \code{assest} directory.
+inside the \code{assets} directory.
 
 \begin{verbatim}
 python ./train_models.py --cfg dataset.cfg --mode svm\
@@ -124,7 +124,7 @@ python datasetVerifyPrediction.py --mode svm\
 \subsubsection*{GUI webcam}
 
 After the classifiers have been trained, you can use them to launch the emotime
-GUI\@. The GUI uses the webcam to  detect emotions.
+GUI\@. The GUI uses the webcam to detect emotions.
 
 \begin{verbatim}
 

--- a/report/parameters.tex
+++ b/report/parameters.tex
@@ -9,7 +9,7 @@ But in order to ensure detection for all treatable faces, we set up a minimum si
 
 Regarding the eye detection step, we decided to set the minimum object threshold to a dynamical value calculated using knowledge of face area size and a qualitative estimation of the human face proportions. In detail, we considered that the width of an eye cannot be smaller than $\frac{1}{5}$ of the face width.
 
-Also we tried several face detectors in order to see which one fits better for our purposes, for example we considered the \texttt{haarcascade\_ frontalface\_default.xml} and the \texttt{haarcascade\_frontalface\_cbcl1.xml}. The latter is interesting because it detects the inner part of the face, discarding the surroundings. This choice has side effects on results~\ref{res:issues}.
+Also we tried several face detectors in order to see which one fits better for our purposes, for example we considered the \code{haarcascade\_frontalface\_ default.xml} and the \code{haarcascade\_frontalface\_cbcl1.xml}. The latter is interesting because it detects the inner part of the face, discarding the surroundings. This choice has side effects on results~\ref{res:issues}.
 
 \subsection{Gabor Kernels Parameters}
 
@@ -57,7 +57,7 @@ In detail, we support multi-class training and detection in the following config
 
 \begin{itemize}
 \item \emph{1 vs 1}, binary classifiers separate single classes from each other.
-\item \emph{1 vs. all}, separates a class from the others.
+\item \emph{1 vs all}, separates a class from the others.
 \item \emph{many vs many}, separates groups of classes.
 \end{itemize}
 

--- a/report/parameters.tex
+++ b/report/parameters.tex
@@ -1,26 +1,26 @@
 \section{Parameters}
 
-In this section we will discuss the parameter used for the algorithm adopted in the class project
+In this section, we will discuss the parameter used for the algorithm adopted in the class project.
 
 \subsection{Face Detection Parameters}
 
-OpenCV support several parameter for multi-scale detection, from the classifier to use, to scale factor and minimum object size. We adopted an empirical approach and used quick-and-dirty python script to test face detection parameters directly using OpenCV implementation: we figured out that considering a 640x490 figure as the minimum face size of size of 120x200 produces good detection on available samples (face/image area ratio aroutd 7-10\%). 
-But in order to ensure detection for all treatable faces we setted up a minimum size of 30x60, this value is related to the resizing performed before feature extraction, in our experiments we chose 48x48.
+OpenCV supports several parameters for multi-scale detection, from the classifier to use, to scale factor and minimum object size. We adopted an empirical approach and used quick-and-dirty python script to test face detection parameters directly using OpenCV implementation: we figured out that considering a 640$\times$490 figure as the minimum face size, size of 120$\times$200 produces good detection on available samples (face/image area ratio around 7-10\%).
+But in order to ensure detection for all treatable faces, we set up a minimum size of 30$\times$60. This value is related to the resizing performed before feature extraction, in our experiments we chose 48$\times$48.
 
-Regarding the eyes detection step, we decided to set the minimum object threshold to a dynamical value calculated using knowledge of face area size and a qualitative estimation of the human face proportions, in detail we consider that the width of an eye cannot be smaller than $\frac{1}{5}$ of the face width.
+Regarding the eye detection step, we decided to set the minimum object threshold to a dynamical value calculated using knowledge of face area size and a qualitative estimation of the human face proportions. In detail, we considered that the width of an eye cannot be smaller than $\frac{1}{5}$ of the face width.
 
-Also we tried several face detector in order to see which one fits better our purposes, for example we considered the \emph{haarcascade\_ frontalface\_default.xml} and the \emph{haarcascade\_frontalface\_cbcl1.xml}. The latter is interesting because it detects the inner part of the face, discarding the surrounding. This choice has side effects on results~\ref{res:issues}.
+Also we tried several face detectors in order to see which one fits better for our purposes, for example we considered the \texttt{haarcascade\_ frontalface\_default.xml} and the \texttt{haarcascade\_frontalface\_cbcl1.xml}. The latter is interesting because it detects the inner part of the face, discarding the surroundings. This choice has side effects on results~\ref{res:issues}.
 
 \subsection{Gabor Kernels Parameters}
 
-Gabor parameters selection is one of the most delicate part of the tuning process, it directly affects the features evaluated for the emotional state classification. 
+Gabor parameter selection is one of the most delicate parts of the tuning process, it directly affects the features evaluated for the emotional state classification.
 %Hopefully \cite{Littlewort04dynamicsof, Bartlett06fullyautomatic, Lades93distortioninvariant} provide some hints on the Gabor bank parameters that can be used to achieve good results, in detail the number of $\lambda$ (wavelength) to use, number of $\theta$ (orientation) and some clues about interesting wavelength ranges are provided:
-In our experimentation we decided to generate Gabor filter banks using relationship reported in previous section, and we have empirically fixed following parameters domain:
+In our experimentation, we decided to generate Gabor filter banks using relationship reported in previous section, and we have empirically fixed following parameters domain:
 
 \begin{itemize}
   \item bandwidth $b \in 1.3,1.6$, %around $\sim \pi \frac{2}{5}, \frac{\pi}{2} $,
-    ranging in common vales of bandwidth\cite{gaborBandwidth}\footnote{\url{http://www.cs.rug.nl/~imaging/simplecell.html}}.
-  \item $\sigma \in 1,6$, and consequentially $\lambda = \frac{\lambda}{\sigma} \sigma $ 
+    ranging in common values of bandwidth\cite{gaborBandwidth}\footnote{\url{http://www.cs.rug.nl/~imaging/simplecell.html}}.
+  \item $\sigma \in 1,6$, and consequentially $\lambda = \frac{\lambda}{\sigma} \sigma $
   \item $\theta \in ( 0 \ldots \frac{\pi}{2} )$
   \item kernel size determined using aspect ratio and scale of the Gaussian support ($\frac{\sigma}{\gamma}$), using the parameters above results from $5$ to $25$ pixels.
 %\item $\lambda \in ( \frac{\pi}{32} \ldots \frac{\pi}{2} ) $ as suggested in \cite{Lades93distortioninvariant}
@@ -28,12 +28,12 @@ In our experimentation we decided to generate Gabor filter banks using relations
 %\item same aspect ration $\gamma$ for each kernel in the bank
 \end{itemize}
 
-We also adopted a flexible approach by keeping subdivision number configurable in order to be able to refine parameters in further development stages. 
-%Least, no clear indication about the size of the kernel, so we decided to support multiple kernel size ranging from $7$ to $17$, this values have been fixed in the first testing phase, using the developed Gabor utilities for visualizing the resulting bank. 
+We also adopted a flexible approach by keeping subdivision number configurable in order to be able to refine parameters in further development stages.
+%Least, no clear indication about the size of the kernel, so we decided to support multiple kernel size ranging from $7$ to $17$, this values have been fixed in the first testing phase, using the developed Gabor utilities for visualizing the resulting bank.
 
 \subsection{Boosting Parameters}
 
-Boosting parameters were considered in the early development stages and have ignored in the latest phases due to the huge amount of time needed for \code{AdaBoost} training. However parameters choice involves:
+Boosting parameters were considered in the early development stages and were ignored in the later phases due to the huge amount of time needed for \code{AdaBoost} training. However parameter choice involves:
 
 \begin{itemize}
 \item Variant of the algorithm to use, in our case \code{Real AdaBoost}, \code{Discrete AdaBoost} and \code{Gentle AdaBoost}.
@@ -41,7 +41,7 @@ Boosting parameters were considered in the early development stages and have ign
 \item Depth of the trained decision tree.
 \end{itemize}
 
-We have no clues about this parameters so we tried several configuration and the better results have been obtained via \emph{Gentle AdaBoost}, trimming weak classifiers provide a speed-up but it is a sensible operation due to distribution of classifier weights. However, as reported in~\ref{res:issues} we have temporary dismissed the boosting approach due to lack of time (and/or servers).
+We have no clue about these parameters so we tried several configurations and better results have been obtained via \emph{Gentle AdaBoost}, trimming weak classifiers provides a speed-up but it is a sensible operation due to distribution of classifier weights. However, as reported in~\ref{res:issues}, we have temporarily dismissed the boosting approach due to lack of time (and/or servers).
 
 \subsection{SVM Parameters}
 
@@ -50,15 +50,15 @@ defines how much to consider the misclassification. Since we hadn't any
 validation set, we couldn't verify how much this value could affect the train.
 We decided to leave $C=0.5$, for no particular reason.
 
-\subsection{Multiclass Strategies}
+\subsection{Multi-class Strategies}
 
-Each classification algorithm adopted works only for binary classification tasks, and our problem involves 7 distinct classes. For this reason we follow the indications in \cite{Littlewort04dynamicsof, Bartlett06fullyautomatic} and implement a quite general support building a voting scheme based multi-class classifier which rely on binary classifiers. 
-In detail we support multi-class training and detection in the following configurations:
+Each classification algorithm adopted works only for binary classification tasks, and our problem involves 7 distinct classes. For this reason, we follow the indications in \cite{Littlewort04dynamicsof, Bartlett06fullyautomatic} and implement a quite general support, building a voting scheme based multi-class classifier which relies on binary classifiers.
+In detail, we support multi-class training and detection in the following configurations:
 
 \begin{itemize}
-\item \emph{1 vs 1}, binary classifiers separate single classes each others.
-\item \emph{1 vs all}, separate a class from the others.
-\item \emph{many vs many}, separate groups of classes.
+\item \emph{1 vs 1}, binary classifiers separate single classes from each other.
+\item \emph{1 vs. all}, separates a class from the others.
+\item \emph{many vs many}, separates groups of classes.
 \end{itemize}
 
-Indication in papers suggest that \emph{1 vs all} and \emph{many vs many} should be the better approaches.
+Indications in papers suggest that \emph{1 vs all} and \emph{many vs many} should be better approaches.

--- a/report/results.tex
+++ b/report/results.tex
@@ -1,39 +1,39 @@
 \section{Results}
 
-We performed training with with several dataset configuration, but here we'll report only the most significant, however the reader may find implementation details, source code, trained models and log at \url{https://github.com/luca-m/emotime/}.
+We performed training with several dataset configurations, but here we'll report only the most significant, however the reader may find implementation details, source code, trained models and log at \url{https://github.com/luca-m/emotime/}.
 
 \subsection{Training Results}
 
-Generalization performance are not formerly available due to the lack of a meaningful validation set\ref{res:issues}, so any generalization performance consideration should be taken as qualitative indications. Having said that we reported good performance in the detection of ``happiness'', ``anger'', ``disgust'', ``neutrality'' and ``surprise'', less effective is the detection of ``contempt'', ``sadness'' and ``fear''. We observed emotion detection happens on expression peeks which can be observed especially during face expression transitions, this behaviour could be caused by our current implementation of the binary classifiers: the SVM classifiers adopted provide a \emph{boolean information} about its prediction, an estimation of distance from the sample and the boundary hyperplane should enable a more gradual detection. 
+Generalization performance is not formerly available due to the lack of a meaningful validation set\ref{res:issues}, so any generalization performance consideration should be taken as qualitative indications. Having said that, we reported good performance in the detection of ``happiness'', ``anger'', ``disgust'', ``neutrality'' and ``surprise'', less effective is the detection of ``contempt'', ``sadness'' and ``fear''. We observed emotion detection happens on expression peeks which can be observed especially during face expression transitions, this behaviour could be caused by our current implementation of the binary classifiers: the SVM classifiers adopted provide a \emph{boolean information} about its prediction, an estimation of distance from the sample and the boundary hyperplane should enable a more gradual detection.
 
-We also observed that the \code{1vsAll} multiclass method provide more less noisy detections during a live web-cam session, \code{1vsAllExt} mode instead is able to always predict a valid state for each frame processed, but sometimes it result to be more unstable during the expression transition. 
+We also observed that the \code{1vsAll} multi-class method provide more less noisy detections during a live web-cam session, \code{1vsAllExt} mode instead is able to always predict a valid state for each frame processed, but sometimes it result to be more unstable during the expression transition.
 
 \subsection{Issues}
 \label{res:issues}
 
-Here a brief discussion about problems and issues in general which remains unsolved due to the limited amount of time available for this class project.
+Here is a brief discussion about problems and issues in general which remain unsolved due to the limited amount of time available for this class project.
 
 \subsubsection*{Training Samples Number}
 
-One of the main problem noticed during testing on arbitrary video or webcam is that detection of some emotions is not good as some other ones, a possible explanation rely on the limited amount of samples of the adopted dataset: some emotions have only 10/20 samples, which is certainly not a huge number.\\
-Also the Cohn-Kanade Expression Database represent only the first step in several articles we have red, typically other dataset flanked to it (MMI, FERET, JAFFE, \ldots).
+One of the main problems noticed during testing on arbitrary video or webcam is that detection of some emotions is not as good as some other ones, a possible explanation relies on the limited amount of samples of the adopted dataset: some emotions have only 10/20 samples, which is certainly not a huge number.\\
+Also the Cohn-Kanade Expression Database represents only the first step in several articles we have read, typically other dataset flanked to it (MMI, FERET, JAFFE, \ldots).
 
 \subsubsection*{Validation Dataset}
 
-The availability of a single, basic dataset did not give us the opportunity to calculate the confusion matrix on validation set for assessing generalization performance. 
+The availability of a single, basic dataset did not give us the opportunity to calculate the confusion matrix on validation set for assessing generalization performance.
 %Also gaining access to datasets is not properly immediate: not automated registration, licence agreement and university affiliation are necessary.
 
 \subsubsection*{Boosting Training Time}
 
-The training time of multiple AdaBoost classifiers with $O(10^4)$ features is not negligible, it took more than a day to complete the whole training process. For this reason we chose to temporary skip the feature selection approach based on the boosting results and focus on SVM with linear kernel. 
+The training time of multiple AdaBoost classifiers with $O(10^4)$ features is not negligible, it took more than a day to complete the whole training process. For this reason, we chose to temporarily skip the feature selection approach based on the boosting results and focus on SVM with linear kernel.
 
-This mean that our performance are not optimal because we may calculate some features which is actually not crucial in the decision process, nevertheless real-time performance are achieved.
+This means that our performance is not optimal because we may calculate some features which are actually not crucial in the decision process, nevertheless real-time performance is achieved.
 
 \subsubsection*{Face Detector Side Effect}
 
-We empirically noted that the face detector adopted for training and detection has side effect on generalization performance, a more formal discussion is not possible due to the lack of validation dataset availability. However we noted that using \code{haarcascade\_frontalface\_default} the face detection rate increase, but part of the ROI of the face is not useful for emotion detection due to the presence of part of background, hair and ears, giving worst generalization performance.
+We empirically noted that the face detector adopted for training and detection has side effect on generalization performance, a more formal discussion is not possible due to the lack of validation dataset availability. However we noted that using \code{haarcascade\_frontalface\_default}, the face detection rate increases, but part of the ROI of the face is not useful for emotion detection due to the presence of part of background, hair and ears, giving worst generalization performance.
 
-Using \code{haarcascade\_frontalface\_cbcl1} only the inner part of the face are detected, this lead to a lower face detection rate but the ROI results more dense of meaningful features. Since we resize ROI to a 48x48 rectangle, which are relatively small images, the effect of the trade-off described above is not negligible.
+Using \code{haarcascade\_frontalface\_cbcl1}, only the inner part of the face is detected, this leads to a lower face detection rate but the ROI results more dense of meaningful features. Since we resize ROI to a 48$\times$48 rectangle, which are relatively small images, the effect of the trade-off described above is not negligible.
 
 \subsection{Examples}
 


### PR DESCRIPTION
Fix a few grammatical and spelling mistakes in:
1. `parameters.tex` (fixed a few formatting issues too),
2. `architecture.tex`,
3. `organization.tex`, and
4. `results.tex`.